### PR TITLE
Fix issues with GTK4 TextInput

### DIFF
--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -231,8 +231,6 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
                 print("[DEBUG CONTAINER] width property: No content, returning 0")
                 return 0
 
-            if self._dirty_widgets and self.needs_redraw:
-                self.recompute()
             width = self.get_width()
             print(f"[DEBUG CONTAINER] width property: returning {width}")
             return width
@@ -247,8 +245,6 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
                 print("[DEBUG CONTAINER] height property: No content, returning 0")
                 return 0
 
-            if self._dirty_widgets and self.needs_redraw:
-                self.recompute()
             height = self.get_height()
             print(f"[DEBUG CONTAINER] height property: returning {height}")
             return height

--- a/gtk/tests_backend/widgets/dateinput.py
+++ b/gtk/tests_backend/widgets/dateinput.py
@@ -1,12 +1,17 @@
 import datetime
 from abc import ABC, abstractmethod
 
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
 
 class DateTimeInputProbe(SimpleProbe, ABC):
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support DateInput or TimeInput testing yet")
+
     native_class = Gtk.Calendar
     supports_limits = True
 

--- a/gtk/tests_backend/widgets/properties.py
+++ b/gtk/tests_backend/widgets/properties.py
@@ -1,9 +1,22 @@
 import pytest
 
-from toga.colors import TRANSPARENT, color as parse_color, rgba
+from toga.colors import TRANSPARENT, rgba
 from toga.fonts import Font
 from toga.style.pack import BOTTOM, CENTER, JUSTIFY, LEFT, RIGHT, TOP
 from toga_gtk.libs import GTK_VERSION, Gtk
+
+
+def _parse_color(native_string):
+    """Parse a color from a GTK4 native RGB(A) string."""
+    if native_string[:4] == "rgba":
+        native_string = native_string[4:]
+    if native_string[:3] == "rgb":
+        native_string = native_string[3:]
+    r, g, b, *a = map(float, native_string.strip("()").split(","))
+    if a:
+        return rgba(r, g, b, a[0])
+    else:
+        return rgba(r, g, b)
 
 
 def toga_color(color):
@@ -16,13 +29,7 @@ def toga_color(color):
                 color.alpha,
             )
         else:  # pragma: no-cover-if-gtk3
-            color = parse_color(color)
-            c = rgba(
-                int(color.r),
-                int(color.g),
-                int(color.b),
-                color.a,
-            )
+            c = _parse_color(color)
 
         # Background color of rgba(0,0,0,0.0) is TRANSPARENT.
         if c.r == 0 and c.g == 0 and c.b == 0 and c.a == 0.0:


### PR DESCRIPTION
Fixes issues with the GTK4 textinput widgets.

This is a PR against your PR over at https://github.com/beeware/toga/pull/3239.  It passes the tests locally except for test_current_winodw but from my understanding that is a separate problem.

-- John