### PR TITLE
Remove debug statements; check GTK4 version in ``supports_current_window_assignment``

### DIFF
--- a/core/src/toga/style/applicator.py
+++ b/core/src/toga/style/applicator.py
@@ -43,15 +43,10 @@ class TogaApplicator:
 
     def refresh(self) -> None:
         # print("RE-EVALUATE LAYOUT", self.widget)
-        print("[DEBUG Applicator] refresh called")
         self.widget.refresh()
 
     def set_bounds(self) -> None:
         # print("  APPLY LAYOUT", self.widget, self.widget.layout)
-        print(
-            f"[DEBUG Applicator] set_bounds called "
-            f"{self.widget} with layout {self.widget.layout}"
-        )
         self.widget._impl.set_bounds(
             self.widget.layout.absolute_content_left,
             self.widget.layout.absolute_content_top,

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -18,10 +18,8 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
     class TogaContainerLayoutManager(Gtk.LayoutManager):
         def __init__(self):
             super().__init__()
-            print("[DEBUG CONTAINER] TogaContainerLayoutManager initialized")
 
         def do_get_request_mode(self, container):
-            print(f"[DEBUG CONTAINER] Getting request mode for container {container}")
             return Gtk.SizeRequestMode.CONSTANT_SIZE
 
         def do_measure(self, container, orientation, for_size):
@@ -32,42 +30,19 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
 
             If the container does not yet have content, the minimum size is set to 0x0.
             """
-            orient_name = (
-                "HORIZONTAL"
-                if orientation == Gtk.Orientation.HORIZONTAL
-                else "VERTICAL"
-            )
-            print(
-                f"[DEBUG CONTAINER] Measuring container: orientation={orient_name}, "
-                f"for_size={for_size}"
-            )
-
+            # print("GET PREFERRED SIZE", self._content)
             if container._content is None:
-                print(
-                    "[DEBUG CONTAINER] Container has no content, returning 0, 0, -1, -1"
-                )
                 return 0, 0, -1, -1
 
             # Ensure we have an accurate min layout size
-            print("[DEBUG CONTAINER] Recomputing container layout for measurement")
             container.recompute()
 
             # The container will conform to the size of the allocation it is given,
             # so the min and preferred size are the same.
             if orientation == Gtk.Orientation.HORIZONTAL:
-                result = container.min_width, container.min_width, -1, -1
-                print(
-                    f"[DEBUG CONTAINER] Horizontal measure result: "
-                    f"min={result[0]}, nat={result[1]}"
-                )
-                return result
+                return container.min_width, container.min_width, -1, -1
             elif orientation == Gtk.Orientation.VERTICAL:
-                result = container.min_height, container.min_height, -1, -1
-                print(
-                    f"[DEBUG CONTAINER] Vertical measure result: "
-                    f"min={result[0]}, nat={result[1]}"
-                )
-                return result
+                return container.min_height, container.min_height, -1, -1
             return None
 
         def do_allocate(self, container, width, height, baseline):
@@ -78,32 +53,19 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
             layout will then be re-computed based on this new available size, and
             that new geometry will be applied to all child widgets of the container.
             """
-            print(
-                f"[DEBUG CONTAINER] Allocating container: "
-                f"width={width}, height={height}, baseline={baseline}"
-            )
+            # print(widget._content, f"Container layout {width}x{height} @ 0x0")
 
             if container._content:
                 current_width = container.width
                 current_height = container.height
                 resized = (width, height) != (current_width, current_height)
 
-                print(
-                    f"[DEBUG CONTAINER] Current container size: "
-                    f"{current_width}x{current_height}, "
-                    f"resized={resized}, needs_redraw={container.needs_redraw}"
-                )
-
                 if resized or container.needs_redraw:
-                    print(f"[DEBUG CONTAINER] Refreshing layout to {width}x{height}")
+                    # print("REFRESH LAYOUT", width, height)
                     container._content.interface.style.layout(container)
                     container.min_width = container._content.interface.layout.min_width
                     container.min_height = (
                         container._content.interface.layout.min_height
-                    )
-                    print(
-                        f"[DEBUG CONTAINER] New min size: "
-                        f"{container.min_width}x{container.min_height}"
                     )
 
                 # WARNING! This is the list of children of the *container*, not
@@ -111,19 +73,15 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
                 # in that tree are direct children of the container.
 
                 # Process each child widget
-                print("[DEBUG CONTAINER] Allocating children:")
-                child_count = 0
                 child_widget = container.get_first_child()
                 while child_widget is not None:
-                    child_count += 1
                     if child_widget.get_visible():
                         # Set the allocation of the child widget to the computed
                         # layout size.
-                        print(
-                            f"[DEBUG CONTAINER] Child {child_count}: "
-                            f"{getattr(child_widget, 'interface', 'unknown')}"
-                        )
-
+                        # print(
+                        #     f" allocate child {child_widget.interface}: "
+                        #     "{child_widget.interface.layout}"
+                        # )
                         child_widget_allocation = Gdk.Rectangle()
                         child_widget_allocation.x = (
                             child_widget.interface.layout.absolute_content_left
@@ -137,31 +95,11 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
                         child_widget_allocation.height = (
                             child_widget.interface.layout.content_height
                         )
-
-                        print(
-                            f"[DEBUG CONTAINER] Allocating at "
-                            f"({child_widget_allocation.x},"
-                            f"{child_widget_allocation.y}) "
-                            f"size {child_widget_allocation.width}x"
-                            f"{child_widget_allocation.height}"
-                        )
                         child_widget.size_allocate(child_widget_allocation, -1)
-                    else:
-                        print(
-                            f"[DEBUG CONTAINER] Child {child_count}: "
-                            f"{getattr(child_widget, 'interface', 'unknown')} "
-                            f"(not visible)"
-                        )
                     child_widget = child_widget.get_next_sibling()
-
-                print(f"[DEBUG CONTAINER] Allocated {child_count} children")
 
             # The layout has been redrawn
             container.needs_redraw = False
-            print(
-                "[DEBUG CONTAINER] Allocation complete, "
-                "container.needs_redraw set to False"
-            )
 
     class TogaContainer(Gtk.Box):
         """A GTK container widget implementing Toga's layout.
@@ -171,13 +109,11 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
 
         def __init__(self):
             super().__init__()
-            print("[DEBUG CONTAINER] TogaContainer initialized")
 
             # Because we don't have access to the existing layout manager, we must
             # create our custom layout manager class.
             layout_manager = TogaContainerLayoutManager()
             self.set_layout_manager(layout_manager)
-            print("[DEBUG CONTAINER] Custom layout manager set")
 
             self._content = None
             self.min_width = 100
@@ -192,14 +128,8 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
 
             # A flag that can be used to explicitly flag that a redraw is required.
             self.needs_redraw = True
-            print(
-                f"[DEBUG CONTAINER] Initial state: "
-                f"min_size={self.min_width}x{self.min_height}, dpi={self.dpi}, "
-                f"needs_redraw={self.needs_redraw}"
-            )
 
         def refreshed(self):
-            print("[DEBUG CONTAINER] Container refreshed called")
             pass
 
         def make_dirty(self, widget=None):
@@ -210,16 +140,7 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
             self.needs_redraw = True
             if widget is not None:
                 self._dirty_widgets.add(widget)
-                print(
-                    f"[DEBUG CONTAINER] Widget {widget} marked as dirty, "
-                    f"dirty count: {len(self._dirty_widgets)}"
-                )
-            else:
-                print(
-                    "[DEBUG CONTAINER] Container marked as dirty (no specific widget)"
-                )
             self.queue_resize()
-            print("[DEBUG CONTAINER] Resize queued")
 
         @property
         def width(self):
@@ -228,11 +149,9 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
             If the container doesn't have any content yet, the width is 0.
             """
             if self._content is None:
-                print("[DEBUG CONTAINER] width property: No content, returning 0")
                 return 0
 
             width = self.get_width()
-            print(f"[DEBUG CONTAINER] width property: returning {width}")
             return width
 
         @property
@@ -242,11 +161,9 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
             If the container doesn't have any content yet, the height is 0.
             """
             if self._content is None:
-                print("[DEBUG CONTAINER] height property: No content, returning 0")
                 return 0
 
             height = self.get_height()
-            print(f"[DEBUG CONTAINER] height property: returning {height}")
             return height
 
         @property
@@ -264,20 +181,14 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
 
         @content.setter
         def content(self, widget):
-            print(f"[DEBUG CONTAINER] Setting container content to {widget}")
             if self._content:
-                print(f"[DEBUG CONTAINER] Removing old content {self._content}")
                 self._content.container = None
 
             self._content = widget
             if widget:
-                print(
-                    f"[DEBUG CONTAINER] Setting container reference on widget {widget}"
-                )
                 widget.container = self
                 self.make_dirty(widget)
             else:
-                print("[DEBUG CONTAINER] No new content, marking container as dirty")
                 self.make_dirty()
 
         def recompute(self):
@@ -286,42 +197,19 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
             Any widgets known to be dirty will be rehinted. The minimum possible
             layout size for the container will also be recomputed.
             """
-            print(
-                f"[DEBUG CONTAINER] recompute() called. Has content: "
-                f"{self._content is not None}, "
-                f"Dirty widgets: {len(self._dirty_widgets)}"
-            )
             if self._content and self._dirty_widgets:
                 # If any of the widgets have been marked as dirty,
                 # recompute their bounds, and re-evaluate the minimum
                 # allowed size for the layout.
-                print(
-                    f"[DEBUG CONTAINER] Rehinting "
-                    f"{len(self._dirty_widgets)} dirty widgets"
-                )
                 while self._dirty_widgets:
                     widget = self._dirty_widgets.pop()
-                    print(f"[DEBUG CONTAINER] Rehinting widget {widget}")
                     widget.rehint()
 
                 # Recompute the layout
-                print("[DEBUG CONTAINER] Recomputing layout for content")
                 self._content.interface.style.layout(self)
 
-                old_min_width = self.min_width
-                old_min_height = self.min_height
                 self.min_width = self._content.interface.layout.min_width
                 self.min_height = self._content.interface.layout.min_height
-                print(
-                    f"[DEBUG CONTAINER] Min size updated: "
-                    f"{old_min_width}x{old_min_height} -> "
-                    f"{self.min_width}x{self.min_height}"
-                )
-            else:
-                print(
-                    "[DEBUG CONTAINER] No content or no dirty widgets, "
-                    "skipping recompute"
-                )
 
 else:  # pragma: no-cover-if-gtk4
 

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -104,12 +104,12 @@ class TextInput(Widget):
             )
             self.interface.intrinsic.height = height[1]
         else:  # pragma: no-cover-if-gtk3
-            print(
-                "[DEBUG TextInput] REHINT",
-                self,
-                self.native.get_preferred_size()[1].width,
-                self.native.get_preferred_size()[1].height,
-            )
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_size()[0].width,
+            #     self.native.get_preferred_size()[0].height,
+            # )
             min_size, size = self.native.get_preferred_size()
 
             self.interface.intrinsic.width = at_least(

--- a/gtk/tests_backend/app.py
+++ b/gtk/tests_backend/app.py
@@ -16,7 +16,11 @@ class AppProbe(BaseProbe, DialogsMixin):
     supports_key = True
     supports_key_mod3 = True
     # Gtk 3.24.41 ships with Ubuntu 24.04 where present() works on Wayland
-    supports_current_window_assignment = not (IS_WAYLAND and GTK_VERSION < (3, 24, 41))
+    # Gtk versions before 4.7.0 has buggy present: https://gitlab.gnome.org/GNOME/gtk/-/commit/4dcacff31
+    supports_current_window_assignment = not (
+        IS_WAYLAND
+        and (GTK_VERSION < (3, 24, 41) or (4, 0, 0) < GTK_VERSION < (4, 7, 0))
+    )
     supports_dark_mode = True
 
     def __init__(self, app):

--- a/gtk/tests_backend/probe.py
+++ b/gtk/tests_backend/probe.py
@@ -13,7 +13,6 @@ class BaseProbe:
 
     async def redraw(self, message=None, delay=0):
         """Request a redraw of the app, waiting until that redraw has completed."""
-        print(f"[DEBUG REDRAW] Redraw called with message: {message}, delay: {delay}")
         if (
             hasattr(self, "native")
             and self.native
@@ -40,9 +39,8 @@ class BaseProbe:
                     with contextlib.suppress(SystemError):
                         frame_clock.disconnect(handler_id)
 
-        print("[DEBUG REDRAW] Processing events to ensure UI is fully updated")
-        events_processed = 0
-        for i in range(15):
+        # Process events to ensure the UI is fully updated
+        for _ in range(15):
             if GTK_VERSION < (4, 0, 0):
                 if Gtk.events_pending():
                     Gtk.main_iteration_do(blocking=False)
@@ -51,20 +49,12 @@ class BaseProbe:
             else:
                 context = GLib.main_context_default()
                 if context.pending():
-                    print(f"[DEBUG REDRAW] GTK4: Processing context iteration {i + 1}")
                     context.iteration(may_block=False)
-                    events_processed += 1
                 else:
-                    print(
-                        f"[DEBUG REDRAW] GTK4: "
-                        f"No more events pending after {events_processed} iterations"
-                    )
                     break
 
         # Always yield to let GTK catch up
-        print("[DEBUG REDRAW] Yielding control with asyncio.sleep(0)")
         await asyncio.sleep(0)
-        print("[DEBUG REDRAW] Redraw method complete")
 
         if toga.App.app.run_slow:
             delay = max(1, delay)

--- a/testbed/tests/widgets/properties.py
+++ b/testbed/tests/widgets/properties.py
@@ -533,11 +533,7 @@ async def test_flex_horizontal_widget_size(widget, probe):
     original_height = probe.height
 
     # Make the widget flexible; it will expand to fill horizontal space
-    print(f"[DEBUG Test] widget intrinsic height {widget.intrinsic.height}")
-    print("[DEBUG Test] Before flex set")
     widget.style.flex = 1
-    print("[DEBUG Test] After flex set")
-    print(f"[DEBUG Test] widget intrinsic height {widget.intrinsic.height}")
 
     # widget has expanded width, but has the same height.
     await probe.redraw(


### PR DESCRIPTION
Removes all debug statements for the Toga PR in order to proceed.

Also adds a GTK4 version check in ``supports_current_window_assignment`` of AppProbe -- without it, Ubuntu 22.04 fails locally with that test.  GTK 3.24.21 released after GTK 4.0; the version was obtained from the GitHub mirror of the GitLab commit linked in the comment above that fixed user-initiated present() on Wayland.

@danyeaw In my opinion this should be the final set of changes required for GTK4 TextInput to work completely.  Congrats on all the work you've done -- we've officially hit the ground running for GTK4 after we get this merged into upstream Toga!!!

I'm not really in a position to ask them -- but my two cents: I think we should get a review requested in the upstream PR I'm merging into, since this is sort of done and GTK4 migration is sort of important.  Thanks

--John

EDIT -- one note:  I did not revert the parts of the commit that changed actual code in the Add Debug Statements commit, specifically using minimum size vs preferred size in TextInput.  That part was kept the same as the current code off of current beeware/toga#3239, instead of reverting the changes to actual code made by "add debug statements [skip ci]."