### PR TITLE
Fixup test redraw; unrelated fix for GTK3

### DIFF
--- a/gtk/tests_backend/probe.py
+++ b/gtk/tests_backend/probe.py
@@ -1,43 +1,11 @@
 import asyncio
-import contextlib
 
 import toga
 from toga_gtk.libs import GLib
 
 
 class BaseProbe:
-    def _queue_draw(self, data):
-        widget, event = data
-        widget.queue_draw()
-        event.set()
-
     async def redraw(self, message=None, delay=0):
-        # Queue a queue_draw, and use frame clock to wait for actual rendering
-        if (
-            hasattr(self, "native")
-            and self.native
-            and hasattr(self.native, "queue_draw")
-        ):
-            draw_queued = asyncio.Event()
-            GLib.idle_add(self._queue_draw, (self.native, draw_queued))
-            await draw_queued.wait()
-            if frame_clock := self.native.get_frame_clock():
-                handler_id = None
-                with contextlib.suppress(asyncio.TimeoutError):
-                    redraw_complete = asyncio.Future()
-
-                    def on_after_paint(*args):
-                        if not redraw_complete.done():
-                            redraw_complete.set_result(True)
-                        return False
-
-                    handler_id = frame_clock.connect("after-paint", on_after_paint)
-
-                    await asyncio.wait_for(redraw_complete, 0.05)
-                if handler_id is not None:
-                    with contextlib.suppress(SystemError):
-                        frame_clock.disconnect(handler_id)
-
         # Process events to ensure the UI is fully updated
         context = GLib.main_context_default()
         while context.pending():

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -1,9 +1,10 @@
 import asyncio
+import contextlib
 from threading import Event
 
 import pytest
 
-from toga_gtk.libs import GTK_VERSION, Gdk, Gtk
+from toga_gtk.libs import GTK_VERSION, Gdk, GLib, Gtk
 
 from ..fonts import FontMixin
 from ..probe import BaseProbe
@@ -53,8 +54,34 @@ class SimpleProbe(BaseProbe, FontMixin):
     def assert_text_align(self, expected):
         assert self.text_align == expected
 
-    def repaint_needed(self):
-        return self.impl.container.needs_redraw or super().repaint_needed()
+    def _queue_draw(self, data):
+        widget, event = data
+        widget.queue_draw()
+        event.set()
+
+    async def redraw(self, message=None, delay=0):
+        # Queue a queue_draw, and use frame clock to wait for actual rendering
+        draw_queued = asyncio.Event()
+        GLib.idle_add(self._queue_draw, (self.native, draw_queued))
+        await draw_queued.wait()
+        if frame_clock := self.native.get_frame_clock():
+            handler_id = None
+            with contextlib.suppress(asyncio.TimeoutError):
+                redraw_complete = asyncio.Future()
+
+                def on_after_paint(*args):
+                    if not redraw_complete.done():
+                        redraw_complete.set_result(True)
+                    return False
+
+                handler_id = frame_clock.connect("after-paint", on_after_paint)
+
+                await asyncio.wait_for(redraw_complete, 0.05)
+            if handler_id is not None:
+                with contextlib.suppress(SystemError):
+                    frame_clock.disconnect(handler_id)
+
+        await super().redraw(message=message, delay=delay)
 
     @property
     def enabled(self):

--- a/gtk/tests_backend/window.py
+++ b/gtk/tests_backend/window.py
@@ -16,7 +16,8 @@ class WindowProbe(BaseProbe, DialogsMixin):
     if GTK_VERSION < (4, 0, 0):
         supports_closable = True
         supports_as_image = True
-        supports_focus = True
+        # Gtk 3.24.41 ships with Ubuntu 24.04 where present() works on Wayland
+        supports_focus = not (IS_WAYLAND and GTK_VERSION < (3, 24, 41))
     else:
         supports_closable = False
         supports_as_image = False


### PR DESCRIPTION
@danyeaw See title.  Use same approach for GTK3 and 4, changes location of queue_draw handling.  Another unrelated fix.

EDIT -- see https://github.com/beeware/toga/pull/3239#issuecomment-3507115187 for rationales