### PR TITLE
Remove extraneous surpress, add clarifying comment about widget focus, minor code simplify

### DIFF
--- a/gtk/tests_backend/probe.py
+++ b/gtk/tests_backend/probe.py
@@ -40,8 +40,7 @@ class BaseProbe:
 
                     await asyncio.wait_for(redraw_complete, 0.05)
                 if handler_id is not None:
-                    with contextlib.suppress(SystemError):
-                        frame_clock.disconnect(handler_id)
+                    frame_clock.disconnect(handler_id)
 
         # Process events to ensure the UI is fully updated
         context = GLib.main_context_default()

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -10,16 +10,6 @@ from ..probe import BaseProbe
 from .properties import toga_color, toga_font
 
 
-def print_children(widget, level=0):
-    indent = "  " * level
-    print(f"{indent}{widget.__class__.__name__}")
-
-    child = widget.get_first_child()
-    while child:
-        print_children(child, level + 1)
-        child = child.get_next_sibling()
-
-
 class SimpleProbe(BaseProbe, FontMixin):
     def __init__(self, widget):
         super().__init__()

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -151,18 +151,7 @@ class SimpleProbe(BaseProbe, FontMixin):
 
     @property
     def has_focus(self):
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
-            return self.native.has_focus()
-        else:  # pragma: no-cover-if-gtk3
-            root = self.native.get_root()
-            focus_widget = root.get_focus()
-            if focus_widget:
-                if focus_widget == self.native:
-                    return self.native.has_focus()
-                else:
-                    return focus_widget.is_ancestor(self.native)
-            else:
-                return False
+        return self.native.has_focus()
 
     async def type_character(self, char):
         if GTK_VERSION >= (4, 0, 0):


### PR DESCRIPTION
Fixes https://github.com/beeware/toga/pull/3239#discussion_r2501432385 and https://github.com/beeware/toga/pull/3239#discussion_r2508267744 (things left in freakboy's review)

Exactly what it says on the tin.

Passing Gtk CI:  https://github.com/johnzhou721/toga/pull/2
Upstream: beeware/toga#3239
Tested locally (Gtk3 and 4) on Ubuntu 22.04

Sorry for the messy intermediate commits.

@danyeaw I also want to bring to attention that when running Tutorial 1, there's an issue with deprecation warnings described at https://github.com/beeware/toga/pull/3239#pullrequestreview-3431139458 -- are you able to reproduce it?  I am not.

Also there's the button sizing issue -- *would you prefer to perform some fixups to the button gtk4 port along with the upstream PR?  Or should we leave it to a separate PR.*

Also is it fine to make PRs to your PR like this?  Is there an alternative way you'd prefer for me to commuincate / add these changes?  Thank you!

--- John

[note -- we can request an upstream review after this finishes and the concerns I pointed out here are addressed.]